### PR TITLE
loosen PyPlot requirement to 2.2.1

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,3 @@
 julia 0.6
-PyPlot 2.3.2
+PyPlot 2.2.1
 DataStructures 0.5.0
-
-
-


### PR DESCRIPTION
earlier versions fail to import on julia 0.6, but this version seems to work okay
(unless there's some known specific bug fix or more recent feature you need?)

most users will upgrade to latest automatically from Pkg.update, the lower bound is in case anyone needs to pin to an older version of PyPlot, if it works correctly it would be better to let them rather than force a downgrade to an old Laplacians version even if the slightly older PyPlot would work correctly.