### PR TITLE
Fixed a small problem with isdefined macro in ichol

### DIFF
--- a/src/matlabSolvers.jl
+++ b/src/matlabSolvers.jl
@@ -22,7 +22,7 @@ Computes a zero-fill incomplete Cholesky factorization of sdd, and returns a fun
 """
 function matlab_ichol(sdd)
 
-    if ~isdefined(:MATLAB)
+    if ~(@isdefined MATLAB)
         error("Type using MATLAB before calling this routine.")
     end
 


### PR DESCRIPTION
Hi Dan,

I changed the syntax of isdefined. I was getting a 2-argument error trying to use this function.

