### PR TITLE
updates for Julia v1.5.1

### DIFF
--- a/src/from_cholmod.jl
+++ b/src/from_cholmod.jl
@@ -19,7 +19,7 @@ Note that this is much faster than actually computing the factorization
 function ask_cholmod(sdd)
     ba = SuiteSparse.CHOLMOD
     #cm = ba.common()
-    cm = ba.defaults(ba.common_struct)
+    cm = ba.defaults(ba.common_struct[Threads.threadid()])
 
     anal = ba.analyze(ba.Sparse(lap(sdd)), cm);
 
@@ -49,7 +49,7 @@ Return the permutation that cholmod would apply.
 function cholmod_perm(sdd)
     ba = SuiteSparse.CHOLMOD
     #cm = ba.common()
-    cm = ba.defaults(ba.common_struct)
+    cm = ba.defaults(ba.common_struct[Threads.threadid()])
 
     anal = ba.analyze(ba.Sparse(lap(sdd)), cm);
 

--- a/src/solverInterface.jl
+++ b/src/solverInterface.jl
@@ -172,7 +172,7 @@ function blockSolver(comps, solvers; tol::Real=1e-6, maxits=Inf, maxtime=Inf, ve
         for i in 1:length(comps)
             ind = comps[i]
             bi = b[ind]
-            x[ind] = (solvers[i])(bi;  tol=tol, maxits=maxits, maxtime=maxtime, verbose=verbose, pcgIts=pcgTmp)
+            x[ind] .= (solvers[i])(bi;  tol=tol, maxits=maxits, maxtime=maxtime, verbose=verbose, pcgIts=pcgTmp)
             if length(pcgIts) > 0
                 pcgIts[1] = max(pcgIts[1],pcgTmp[1])
             end


### PR DESCRIPTION
A few quick fixes so that tests pass on Julia 1.4.1 and Julia 1.5.1. These changes may be breaking for earlier versions of Julia, depending on which version of SuiteSparse is loaded. See https://github.com/JuliaLang/julia/pull/34546/commits/65ca43c5308e7ab3bea0f78040e160151032f086