### PR TITLE
Forgot to extend `csumspace_rev` as the size of `colspace` grows after the original allocation.

### DIFF
--- a/src/approxChol.jl
+++ b/src/approxChol.jl
@@ -941,6 +941,9 @@ function approxChol(a::LLMatOrd{Tind,Tval}, merge::Int) where {Tind,Tval}
         # Compress the incident edges and hold their references into `colspace`.
         local len = get_ll_col(a, i, colspace)
         len = compressAvgSortCol!(colspace, len, merge)
+        if length(csumspace_rev) < len
+            resize!(csumspace_rev, len)
+        end
 
         # Partial construction of the output structure for this elimination.
         ldli.col[i] = i


### PR DESCRIPTION
Hi, @rjkyng!
Please take a look now.
The notebook demo passes now (as do my IPM tests; I just didn't try with a lot of splits before, and the initial allocations of the vector were accidentally sufficient).