### PR TITLE
Fix the `bndry_chimera()` function.

### DIFF
--- a/src/graphGenerators.jl
+++ b/src/graphGenerators.jl
@@ -1062,7 +1062,7 @@ It returns an SDDM matrix.
 function bndry_chimera(n::Integer, k::Integer; verbose=false, prefix="", ver=Vcur)
     a = chimera(n, k; verbose=verbose, prefix=prefix, ver=ver)
     L = lap(a)
-    int = setdiff(1:n,1:ceil(n^(1/3)):n)
+    int = setdiff(1:n,1:ceil(Int, n^(1/3)):n)
     M = L[int, int]
     return M
 end
@@ -1084,7 +1084,7 @@ function uni_bndry_chimera(n::Integer, k::Integer; verbose=false, prefix="", ver
     a = chimera(n, k; verbose=verbose, prefix=prefix, ver=ver)
     unweight!(a)
     L = lap(a)
-    int = setdiff(1:n,1:ceil(n^(1/3)):n)
+    int = setdiff(1:n,1:ceil(Int, n^(1/3)):n)
     M = L[int, int]
     return M
 end
@@ -1225,3 +1225,4 @@ function star_join(a, k)
 
     return sparse(ai,aj,av)
 end
+


### PR DESCRIPTION
Ceil returns floating point, which causes `setdiff()` to promote the return type into `Float64` even though we started with `1:n` (and assumed it to be integral). That causes trouble with indexing.

Example:

```julia
julia> n = 300;
julia> a = randn(n);
julia> a[setdiff(1:n,1:ceil(Int, n^(1/3)):n)];
julia> a[setdiff(1:n,1:ceil(n^(1/3)):n)];
ERROR: ArgumentError: invalid index: 2.0 of type Float64
Stacktrace:
  [1] to_index(i::Float64)
    @ Base ./indices.jl:300
  [2] to_index(A::Vector{Float64}, i::Float64)
    @ Base ./indices.jl:277
  [3] _to_indices1(A::Vector{Float64}, inds::Tuple{Base.OneTo{Int64}}, I1::Float64)
    @ Base ./indices.jl:359
  [4] to_indices
    @ Base ./indices.jl:354 [inlined]
  [5] to_indices
    @ Base ./indices.jl:345 [inlined]
  [6] getindex
    @ Base ./abstractarray.jl:1288 [inlined]
  [7] macro expansion
    @ Base ./multidimensional.jl:917 [inlined]
  [8] macro expansion
    @ Base ./cartesian.jl:64 [inlined]
  [9] _unsafe_getindex!
    @ Base ./multidimensional.jl:912 [inlined]
 [10] _unsafe_getindex
    @ Base ./multidimensional.jl:903 [inlined]
 [11] _getindex
    @ Base ./multidimensional.jl:889 [inlined]
 [12] getindex(A::Vector{Float64}, I::Vector{Float64})
    @ Base ./abstractarray.jl:1288
 [13] top-level scope
    @ REPL[16]:1
```