### PR TITLE
Handle the "maybe extend" behaviour of `extendMatrix()` more appropriately.

### DIFF
--- a/src/graphOps.jl
+++ b/src/graphOps.jl
@@ -49,7 +49,7 @@ end
 
 
 """
-Add a new vertex to a with weights to the other vertices corresponding to diagonal surplus weight.
+*May* add a new vertex to a with weights to the other vertices corresponding to diagonal surplus weight. But if there is no surplus weight at all, then return just the input matrix.
 
 This is an efficient way of writing [a d; d' 0]
 """


### PR DESCRIPTION
Currently, if the given SDDM has a very small diagonal, the extension does not happen, but the RHS is augmented anyway. This causes a crash.

Example:
```julia
using Laplacians
using Statistics
using SparseArrays
using LinearAlgebra

n = 5;
A = Laplacians.uni_chimera(5, 1) * 5;  # heavyweight connected graph
L = Laplacians.lap(A);
M = L + sparse(I, n, n) * eps(Float64);  # with lightweight extra diagonal value
params = Laplacians.ApproxCholParams(:deg, 2, 2);
f = Laplacians.approxchol_sddm(M; params = params, verbose = false);
b = randn(n); b .-= mean(b);

@show f(b)  # this used to crash
```