### PR TITLE
Handle the "maybe extend" behaviour of `extendMatrix()` more appropriately.

### DIFF
--- a/src/graphOps.jl
+++ b/src/graphOps.jl
@@ -49,7 +49,7 @@ end
 
 
 """
-Add a new vertex to a with weights to the other vertices corresponding to diagonal surplus weight.
+*May* add a new vertex to a with weights to the other vertices corresponding to diagonal surplus weight. But if there is no surplus weight at all, then return just the input matrix.
 
 This is an efficient way of writing [a d; d' 0]
 """


### PR DESCRIPTION
Currently, if the given SDDM has a very small diagonal, the extension does not happen, but the RHS is augmented anyway. This causes a crash, since the matrix and RHS does not have compatible dimensions anymore. This PR fixes this by falling back to the Laplacian solver if the SDDM input matrix turns out to be not an SDDM (or one with very small diagonal excess).